### PR TITLE
Add Hetzner server creation with cloud-init, swap, and configurable runners

### DIFF
--- a/hetzner/README.md
+++ b/hetzner/README.md
@@ -1,20 +1,175 @@
-<p align="left"><img src="https://www.versio.io/img/supported-technology/hetzner-cloud.svg"></p
-<h1>Hetzner runner deployments</h1>
+<p align="left"><img src="https://www.versio.io/img/supported-technology/hetzner-cloud.svg"></p>
+<h1>Hetzner GitHub Actions Runner Deployment</h1>
 
-## Usage
+This action creates and manages Hetzner Cloud servers with GitHub Actions runners pre-installed via cloud-init.
+
+## Features
+
+- 🚀 **Automated provisioning** - Creates Hetzner servers with cloud-init
+- 🐳 **Docker pre-installed** - Each server comes with Docker ready
+- 🏃 **Multiple runners** - Configure multiple runners per server
+- 💾 **10GB swap** - Automatic swap file for better memory management
+- 🔧 **Armbian-config integration** - Uses armbian-config for runner installation
+- 🗑️ **Automatic cleanup** - Delete servers when done
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `action` | Yes | - | Action to perform: `create` or `delete` |
+| `server-type` | No | `cax31` | Hetzner server type (e.g., cax21, cax31, cax41) |
+| `image` | No | `ubuntu-24.04` | OS image name |
+| `ssh-key` | Yes | - | SSH key name in Hetzner Cloud |
+| `index` | No | `0` | Server index (for matrix builds) |
+| `delete-existing` | No | `false` | Delete existing server before creating |
+| `hetzner-token` | Yes | - | Hetzner Cloud API token |
+| `github-token` | No* | - | GitHub token for runner registration |
+| `runner-count` | No | `2` | Number of runners per server |
+
+*Required for `create` action
+
+## Usage Examples
+
+### Basic server creation
 
 ```yaml
-- name: Enable Hetzner Virtual Machines
+- name: Create Hetzner server
   uses: armbian/actions/hetzner@main
   with:
-    action-type: enable # enable or disable VM cluster
-    machine-type: cax21|cax31|... # machine type
-    machine-id: 0,1,2 ... # selected machine
-    runners-count: 1,2,3 # runners per machine
-    machine-count: 1,2,3 # numbers of machines
-    key: ${{ secrets.KEY_TORRENTS }} # key which we have in the Hezner API
-    known_hosts: ${{ secrets.KNOWN_HOSTS_TORRENTS }}  # key_knowns_hosts which we have in the Hezner API
-    hetzner_id: ${{ secrets.HETZNER_ONE }} # hetzner API token
-    github_token: ${{ secrets.ACCESS_TOKEN }} # github action token
-
+    action: create
+    server-type: cax41
+    index: 0
+    ssh-key: "UPLOAD"
+    hetzner-token: ${{ secrets.HETZNER_ONE }}
+    github-token: ${{ secrets.GITHUB_RUNNER }}
+    runner-count: 4
 ```
+
+### Matrix strategy for multiple servers
+
+```yaml
+name: Enable Hetzner Runners
+on:
+  workflow_dispatch:
+
+env:
+  MACHINE: 'cax41'
+  MACHINE_COUNT: '4'
+  RUNNER_COUNT: '4'
+
+jobs:
+  Prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{steps.matrix.outputs.matrix}}
+    steps:
+      - name: Generate matrix
+        id: matrix
+        run: |
+          count=${{ env.MACHINE_COUNT }}
+          matrix=$(seq 0 $(( count - 1 )) | jq -cnR '[inputs | tonumber]')
+          echo "matrix=${matrix}" >> $GITHUB_OUTPUT
+
+  Create:
+    needs: Prepare
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        index: ${{fromJson(needs.Prepare.outputs.matrix)}}
+    steps:
+      - name: Create Hetzner server
+        uses: arengmbian/actions/hetzner@main
+        with:
+          action: create
+          server-type: "${{ env.MACHINE }}"
+          index: "${{ matrix.index }}"
+          delete-existing: "true"
+          ssh-key: "UPLOAD"
+          hetzner-token: ${{ secrets.HETZNER_ONE }}
+          github-token: ${{ secrets.GITHUB_RUNNER }}
+          runner-count: "${{ env.RUNNER_COUNT }}"
+```
+
+### With automatic cleanup
+
+```yaml
+jobs:
+  Create:
+    # ... server creation ...
+
+  Work:
+    needs: Create
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hold servers
+        run: sleep "110m"
+
+  Cleanup:
+    needs: Work
+    if: always()  # Runs even if Work fails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Hetzner server
+        uses: armbian/actions/hetzner@main
+        with:
+          action: delete
+          server-type: "cax41"
+          index: "0"
+          ssh-key: "UPLOAD"
+          hetzner-token: ${{ secrets.HETZNER_ONE }}
+```
+
+## Server Configuration
+
+Each server is automatically configured with:
+
+- **Docker** - Installed via get.docker.com
+- **Armbian config repository** - Added for armbian-config installation
+- **Armbian-config** - Installed for runner management
+- **GitHub Actions runners** - Configured via armbian-config with:
+  - Runner labels: `alfa`, `images`
+  - Organization: `armbian`
+  - Count: Specified by `runner-count` input
+- **10GB swap file** - For improved memory management
+
+## Server Naming
+
+Servers are named using the pattern: `hetzner-{index}`
+
+For example, with `index: 0`, the server will be named `hetzner-runner-0`.
+
+## Permissions Required
+
+The workflow needs these permissions:
+- `contents: read` - To checkout the action
+- `actions: write` - If updating outputs or creating summaries
+
+## Secrets
+
+You'll need to configure these secrets in your repository:
+
+- `HETZNER_ONE` - Hetzner Cloud API token
+- `GITHUB_RUNNER` - GitHub personal access token with `repo` scope
+- `UPLOAD` - SSH key name in Hetzner Cloud (must exist in your account)
+
+## Troubleshooting
+
+### Server creation fails
+
+1. Verify your Hetzner API token has sufficient permissions
+2. Check that the SSH key exists in your Hetzner Cloud account
+3. Ensure the server type is available in your region
+
+### Runners not registering
+
+1. Verify the GitHub token has `repo` scope
+2. Check that the armbbian-config repository is accessible
+3. Review cloud-init logs in the server console
+
+### Cleanup doesn't run
+
+Ensure the Cleanup job has `if: always()` to run even when previous jobs fail.
+
+## License
+
+MIT

--- a/hetzner/action.yml
+++ b/hetzner/action.yml
@@ -1,123 +1,96 @@
-name: "Enable Hetzner VMs"
+name: "Create Hetzner Servers"
 author: "Igor Pecovnik"
+description: "Create Hetzner Cloud servers via matrix strategy"
+
 inputs:
-  action-type:
+  action:
     required: true
-  machine-type:
-    required: true
-  machine-id:
+    description: "Action: 'create' or 'delete'"
+  server-type:
     required: false
-  machine-count:
+    description: "Hetzner server type (e.g., cax21, cax31, cax41)"
+    default: "cax31"
+  image:
+    required: false
+    description: "OS image name"
+    default: "ubuntu-24.04"
+  ssh-key:
     required: true
-  runners-count:
+    description: "SSH key name in Hetzner Cloud"
+  index:
+    required: false
+    description: "Server index (for matrix builds)"
+    default: "0"
+  delete-existing:
+    required: false
+    description: "Delete existing server before creating"
+    default: "false"
+  hetzner-token:
     required: true
-  key:
-    required: true
-  known_hosts:
-    required: true
-  hetzner_id:
-    required: true
-  github_token:
-    required: true
+    description: "Hetzner Cloud API token"
+  github-token:
+    required: false
+    description: "GitHub token for runner registration (required for create action)"
+  runner-count:
+    required: false
+    description: "Number of runners per machine"
+    default: "2"
 
-concurrency:
-  cancel-in-progress: false
-
-runs:  
+runs:
   using: "composite"
   steps:
-
-    - name: Install SSH key for storage
-      if: ${{ github.repository_owner == 'Armbian' }}
-      uses: shimataro/ssh-key-action@v2
-      with:
-        key: ${{ inputs.key }}
-        known_hosts: ${{ inputs.known_hosts }}
-        if_key_exists: replace
-
-    - name: Install Homebrew
-      if: ${{ github.repository_owner == 'Armbian' }}
+    - name: Setup Python
       shell: bash
       run: |
+        if command -v python3 &> /dev/null; then
+          echo "Python3 already installed"
+        else
+          echo "Installing Python3..."
+          apt-get update -qq
+          apt-get install -y -qq python3 python3-pip
+        fi
 
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> ${HOME}/.bash_profile
+    - name: Install hcloud
+      shell: bash
+      run: |
+        pip3 install --break-system-packages hcloud || pip3 install hcloud
 
-    - name: Install CLI for Hetzner Cloud
-      if: ${{ github.repository_owner == 'Armbian' }}
+    - name: Create/Delete Hetzner Server
       shell: bash
       env:
-        HCLOUD_TOKEN: ${{ inputs.hetzner_id }}
+        HCLOUD_TOKEN: ${{ inputs.hetzner-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
+        set -e
 
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        brew install hcloud
-        hcloud server list
+        CMD="python3 ${{ github.action_path }}/create_servers.py \
+          ${{ inputs.action }} \
+          --server-type ${{ inputs.server-type }} \
+          --image ${{ inputs.image }} \
+          --ssh-key ${{ inputs.ssh-key }} \
+          --index ${{ inputs.index }}"
 
-    - name: "Kill runners"
-      if: ${{ github.repository_owner == 'Armbian' && inputs.action-type == 'enable' }}
-      env:
-        HCLOUD_TOKEN: ${{ inputs.hetzner_id }}
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS: 3650
-      shell: bash
-      run: |
+        if [[ "${{ inputs.action }}" == "create" ]]; then
+          CMD="${CMD} --count 1 --runner-count ${{ inputs.runner-count }}"
+          if [[ "${{ inputs.delete-existing }}" == "true" ]]; then
+            CMD="${CMD} --delete-existing"
+          fi
+        else
+          CMD="${CMD} --count 1"
+        fi
 
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        machinenames=("Faerie" "November" "Raven" "Hammer" "Foxtrot" "Papa" "Chimera" "Panther")
-        machinename="${machinenames[${{ inputs.machine-id }}]}"
-        machinenameid=$(hcloud server list --output columns=id,name | grep ${machinename} | cut -d" " -f1 || true)
-        [[ -n "${machinenameid}" ]] && hcloud server delete "${machinenameid}" || true
+        echo "Running: $CMD"
+        RESULT=$(eval $CMD)
+        EXIT_CODE=$?
 
-    - name: "Kill runners"
-      if: ${{ github.repository_owner == 'Armbian' && inputs.action-type == 'disable' }}
-      env:
-        HCLOUD_TOKEN: ${{ inputs.hetzner_id }}
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS: 3650
-      shell: bash
-      run: |
+        echo "### Result" >> $GITHUB_STEP_SUMMARY
+        echo '```json' >> $GITHUB_STEP_SUMMARY
+        echo "${RESULT}" >> $GITHUB_STEP_SUMMARY
+        echo '```' >> $GITHUB_STEP_SUMMARY
 
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        # we will set fixed number and fixed machine names        
-        machinenames=("Faerie" "November" "Raven" "Hammer" "Foxtrot" "Papa" "Chimera" "Panther")
-        for machinename in "${machinenames[@]}"
-        do
-          machinenameid=$(hcloud server list --output columns=id,name | grep ${machinename} | cut -d" " -f1 || true)
-          [[ -n "${machinenameid}" ]] && hcloud server delete "${machinenameid}" || true
-        done
+        echo "${RESULT}"
 
-    - name: "Deploy runners"
-      if: ${{ inputs.action-type == 'enable' }}
-      env:
-        HCLOUD_TOKEN: ${{ inputs.hetzner_id }}        
-        GH_TOKEN: ${{ inputs.github_token }}
-        HOMEBREW_NO_AUTO_UPDATE: 1
-        HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS: 3650
-      shell: bash
-      run: |
-
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        machinenames=("Faerie" "November" "Raven" "Hammer" "Foxtrot" "Papa" "Chimera" "Panther")
-        machinename="${machinenames[${{ inputs.machine-id }}]}"
-        echo -e '#!/bin/bash\n\
-        export STOP=${{ inputs.runners-count}} NAME=${machinename} GH_TOKEN=${{ env.GH_TOKEN }}\n\
-        git clone https://github.com/armbian/scripts\ncd scripts/generate-runners\n\
-        ./deploy.sh" | \
-        hcloud server create --name ${machinename} --image ubuntu-22.04 --type ${{ inputs.machine-type }} --ssh-key TORRENT --user-data-from-file -
-        
-    - name: Remove runners
-      if: ${{ inputs.action-type == 'disable' }}
-      env:
-        GH_TOKEN: ${{ inputs.github_token }}
-      shell: bash
-      run: |
-
-        # make sure all are down
-        sleep 60
-
-        RUNNERS=$(gh api \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        "/repos/armbian/os/actions/runners?per_page=1000" | \
-        jq -r '.runners[] | select(.labels[].name=="temp")' | jq '.id')
+        if [ $EXIT_CODE -ne 0 ]; then
+          echo "::error::Action failed with exit code ${EXIT_CODE}"
+          exit $EXIT_CODE
+        fi

--- a/hetzner/create_servers.py
+++ b/hetzner/create_servers.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""
+Simple Hetzner Server Creator
+
+Creates N Hetzner Cloud servers with specified configuration.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+try:
+    from hcloud import Client
+    from hcloud.images import Image
+    from hcloud.server_types import ServerType
+    from hcloud.ssh_keys import SSHKey
+    from hcloud.servers.domain import Server
+except ImportError as e:
+    print(f"Missing required library: {e}")
+    print("Install with: pip install hcloud")
+    sys.exit(1)
+
+
+# Server name prefix
+SERVER_PREFIX = "hetzner-runner"
+
+
+def get_cloud_init_config(github_token: str, runner_name: str, runner_count: int = 2) -> str:
+    """Generate cloud-init configuration with GitHub token injected."""
+    return f"""#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - curl
+  - git
+  - ca-certificates
+
+runcmd:
+  # Install Docker
+  - curl -fsSL https://get.docker.com -o get-docker.sh
+  - sh get-docker.sh
+  - usermod -aG docker root
+
+  # Add Armbian GPG key
+  - curl -fsSL https://apt.armbian.com/armbian.key | gpg --dearmor -o /usr/share/keyrings/armbian.gpg
+
+  # Add Armbian config repository
+  - |
+    cat << EOF | tee /etc/apt/sources.list.d/armbian-config.sources > /dev/null
+    Types: deb
+    URIs: https://github.armbian.com/configng
+    Suites: stable
+    Components: main
+    Signed-By: /usr/share/keyrings/armbian.gpg
+    EOF
+
+  # Update package list and install armbian-config
+  - apt-get update
+  - apt-get install -y armbian-config
+
+  # Create 10GB swap file
+  - fallocate -l 10G /swapfile
+  - chmod 600 /swapfile
+  - mkswap /swapfile
+  - swapon /swapfile
+  - echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
+  # Install GitHub Actions runners (start=1 stop={runner_count} installs {runner_count} runners)
+  - armbian-config --api module_armbian_runners install gh_token={github_token} runner_name={runner_name} start=1 stop={runner_count} label_primary=alfa label_secondary=images organisation=armbian
+
+  # Clean up
+  - rm -f get-docker.sh
+
+final_message: "Server configuration complete!"
+"""
+
+
+def create_server(
+    client: Client,
+    name: str,
+    server_type: str,
+    image: str,
+    ssh_key_name: str,
+    github_token: str,
+    delete_existing: bool = False,
+    runner_count: int = 2,
+) -> dict:
+    """
+    Create a single Hetzner server.
+
+    Args:
+        client: Hetzner client
+        name: Server name
+        server_type: Server type (e.g., cax21, cax31)
+        image: Image name (e.g., ubuntu-22.04)
+        ssh_key_name: SSH key name in Hetzner
+        delete_existing: Delete existing server if present
+        runner_count: Number of runners to install
+
+    Returns:
+        Dict with server info
+    """
+    # Check if server exists
+    existing = client.servers.get_by_name(name)
+    if existing:
+        if delete_existing:
+            print(f"Deleting existing server: {name}")
+            client.servers.delete(existing)
+            time.sleep(2)  # Wait for deletion
+        else:
+            return {
+                "name": name,
+                "status": "exists",
+                "id": existing.id,
+                "public_ip": existing.public_net.ipv4.ip if existing.public_net else None,
+            }
+
+    # Get SSH key
+    ssh_keys = client.ssh_keys.get_all()
+    ssh_key = None
+    for key in ssh_keys:
+        if key.name == ssh_key_name:
+            ssh_key = key
+            break
+
+    if not ssh_key:
+        print(f"Warning: SSH key '{ssh_key_name}' not found, creating without SSH key")
+
+    # Get cloud-init config with GitHub token
+    user_data = get_cloud_init_config(github_token, name, runner_count)
+
+    # Create server
+    print(f"Creating server: {name}")
+    response = client.servers.create(
+        name=name,
+        server_type=ServerType(name=server_type),
+        image=Image(name=image),
+        ssh_keys=[ssh_key] if ssh_key else [],
+        user_data=user_data,
+    )
+
+    # Wait for server creation to complete
+    if response.action:
+        response.action.wait_until_finished()
+
+    # Get the server
+    server = client.servers.get_by_name(name)
+
+    # Wait for server to be running
+    print(f"Waiting for {name} to be running...")
+    for _ in range(60):  # Wait up to 5 minutes
+        server = client.servers.get_by_name(name)
+        if server.status == Server.STATUS_RUNNING:
+            break
+        time.sleep(5)
+
+    return {
+        "name": name,
+        "status": server.status,
+        "id": server.id,
+        "public_ip": server.public_net.ipv4.ip if server.public_net else None,
+        "server_type": server.server_type.name,
+        "image": server.image.name if server.image else None,
+    }
+
+
+def delete_servers(
+    client: Client,
+    server_names: list[str],
+) -> dict:
+    """
+    Delete servers by name.
+
+    Args:
+        client: Hetzner client
+        server_names: List of server names to delete
+
+    Returns:
+        Dict with deletion results
+    """
+    results = []
+    for name in server_names:
+        server = client.servers.get_by_name(name)
+        if server:
+            print(f"Deleting server: {name} (ID: {server.id})")
+            client.servers.delete(server)
+            results.append({"name": name, "status": "deleted", "id": server.id})
+        else:
+            results.append({"name": name, "status": "not_found"})
+
+    return {"deleted": len([r for r in results if r["status"] == "deleted"])}
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Create Hetzner Cloud servers"
+    )
+    parser.add_argument(
+        "action",
+        choices=["create", "delete"],
+        help="Action to perform"
+    )
+    parser.add_argument(
+        "--hetzner-token",
+        default=os.environ.get("HCLOUD_TOKEN"),
+        help="Hetzner Cloud API token (HCLOUD_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--github-token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help="GitHub token for runner registration (GITHUB_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--server-type",
+        default="cax31",
+        help="Server type (default: cax31)",
+    )
+    parser.add_argument(
+        "--image",
+        default="ubuntu-24.04",
+        help="Image name (default: ubuntu-24.04)",
+    )
+    parser.add_argument(
+        "--ssh-key",
+        default="UPLOAD",
+        help="SSH key name in Hetzner (default: UPLOAD)",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Number of servers to create (default: 1)",
+    )
+    parser.add_argument(
+        "--index",
+        type=int,
+        default=0,
+        help="Starting index for server names (default: 0)",
+    )
+    parser.add_argument(
+        "--delete-existing",
+        action="store_true",
+        help="Delete existing servers before creating",
+    )
+    parser.add_argument(
+        "--runner-count",
+        type=int,
+        default=2,
+        help="Number of runners per server (default: 2)",
+    )
+
+    args = parser.parse_args()
+
+    if not args.hetzner_token:
+        print("Error: Hetzner token required (use --hetzner-token or HCLOUD_TOKEN env var)")
+        sys.exit(1)
+
+    # GitHub token only required for create action
+    if args.action != "delete" and not args.github_token:
+        print("Error: GitHub token required for create action (use --github-token or GITHUB_TOKEN env var)")
+        sys.exit(1)
+
+    # Create client
+    client = Client(
+        token=args.hetzner_token,
+        application_name="gh-runner-deployer",
+        application_version="1.0.0",
+    )
+
+    if args.action == "delete":
+        # Delete servers
+        server_names = [f"{SERVER_PREFIX}-{i}" for i in range(args.index, args.index + args.count)]
+        result = delete_servers(client, server_names)
+    else:
+        # Create servers
+        servers = []
+        for i in range(args.count):
+            server_name = f"{SERVER_PREFIX}-{args.index + i}"
+            server = create_server(
+                client,
+                name=server_name,
+                server_type=args.server_type,
+                image=args.image,
+                ssh_key_name=args.ssh_key,
+                github_token=args.github_token,
+                delete_existing=args.delete_existing,
+                runner_count=args.runner_count,
+            )
+            servers.append(server)
+
+        result = {
+            "action": "create",
+            "servers": servers,
+        }
+
+    # Output JSON
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hetzner/deploy_runners.py
+++ b/hetzner/deploy_runners.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""
+Hetzner GitHub Actions Runner Deployment Script
+
+This script creates Hetzner Cloud servers and installs GitHub Actions runners
+using armbian-config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import time
+import json
+from pathlib import Path
+from typing import List, Dict, Optional
+
+try:
+    from hcloud import Client
+    from hcloud.images import Image
+    from hcloud.server_types import ServerType
+    from hcloud.ssh_keys import SSHKey
+    from hcloud.actions import Action
+    from hcloud.servers.domain import Server
+    import paramiko
+except ImportError as e:
+    print(f"Missing required library: {e}")
+    print("Install with: pip install hcloud paramiko")
+    sys.exit(1)
+
+
+# Machine names for runners
+MACHINE_NAMES = [
+    "Faerie", "November", "Raven", "Hammer",
+    "Foxtrot", "Papa", "Chimera", "Panther"
+]
+
+
+class RunnerDeployer:
+    """Manages Hetzner server creation and runner deployment."""
+
+    def __init__(
+        self,
+        hetzner_token: str,
+        github_token: str,
+        ssh_key_path: Optional[str] = None,
+        ssh_key_name: str = "TORRENT",
+        machine_type: str = "cax31",
+        image_name: str = "ubuntu-22.04",
+        runner_name: str = "runner",
+        start: int = 1,
+        stop: int = 24,
+        label_primary: str = "self-hosted",
+        label_secondary: str = "",
+        organisation: str = "",
+    ):
+        """
+        Initialize the deployer.
+
+        Args:
+            hetzner_token: Hetzner Cloud API token
+            github_token: GitHub personal access token
+            ssh_key_path: Path to SSH private key (optional, uses env SSH_KEY if not provided)
+            ssh_key_name: Name of SSH key in Hetzner Cloud
+            machine_type: Hetzner server type (e.g., cax21, cax31, cax41)
+            image_name: OS image name
+            runner_name: Base name for the runner
+            start: Start hour for runner availability
+            stop: Stop hour for runner availability
+            label_primary: Primary labels for the runner
+            label_secondary: Secondary labels for the runner
+            organisation: GitHub organization name
+        """
+        self.hetzner_token = hetzner_token
+        self.github_token = github_token
+        self.ssh_key_path = ssh_key_path
+        self.ssh_key_name = ssh_key_name
+        self.machine_type = machine_type
+        self.image_name = image_name
+        self.runner_name = runner_name
+        self.start = start
+        self.stop = stop
+        self.label_primary = label_primary
+        self.label_secondary = label_secondary
+        self.organisation = organisation
+
+        self.client = Client(
+            token=hetzner_token,
+            application_name="armbian-runner-deployer",
+            application_version="1.0.0",
+        )
+
+        # Load SSH key content for Paramiko
+        self._init_ssh_key()
+
+    def _init_ssh_key(self):
+        """Initialize SSH key from file or environment."""
+        if self.ssh_key_path and os.path.exists(self.ssh_key_path):
+            with open(self.ssh_key_path, 'r') as f:
+                self.ssh_key_content = f.read()
+        else:
+            # Try environment variable
+            self.ssh_key_content = os.environ.get('SSH_KEY', '')
+            if not self.ssh_key_content:
+                raise ValueError("SSH key not found. Provide ssh_key_path or set SSH_KEY env var.")
+
+    def get_ssh_key(self) -> Optional[SSHKey]:
+        """Get the SSH key object from Hetzner."""
+        ssh_keys = self.client.ssh_keys.get_all()
+        for key in ssh_keys:
+            if key.name == self.ssh_key_name:
+                return key
+        return None
+
+    def server_exists(self, name: str) -> bool:
+        """Check if a server with the given name exists."""
+        servers = self.client.servers.get_all()
+        return any(s.name == name for s in servers)
+
+    def delete_server(self, name: str) -> bool:
+        """Delete a server by name."""
+        servers = self.client.servers.get_all()
+        for server in servers:
+            if server.name == name:
+                print(f"Deleting existing server: {name} (ID: {server.id})")
+                self.client.servers.delete(server)
+                return True
+        return False
+
+    def wait_for_server_running(self, server_name: str, timeout: int = 300) -> bool:
+        """
+        Wait for server to be in running state.
+
+        Args:
+            server_name: Name of the server to wait for
+            timeout: Maximum time to wait in seconds
+
+        Returns:
+            True if server is running, False if timeout
+        """
+        print(f"Waiting for server {server_name} to be running...")
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            server = self.client.servers.get_by_name(server_name)
+            if server and server.status == Server.STATUS_RUNNING:
+                print(f"Server {server_name} is running!")
+                return True
+            elif server:
+                print(f"Server status: {server.status}...")
+            time.sleep(5)
+
+        print(f"Timeout waiting for server {server_name}")
+        return False
+
+    def get_server_public_ip(self, server_name: str) -> Optional[str]:
+        """Get the public IPv4 address of a server."""
+        server = self.client.servers.get_by_name(server_name)
+        if server and server.public_net:
+            return server.public_net.ipv4.ip
+        return None
+
+    def execute_ssh_command(
+        self,
+        host: str,
+        command: str,
+        timeout: int = 300
+    ) -> tuple[int, str, str]:
+        """
+        Execute a command via SSH.
+
+        Args:
+            host: Server IP address
+            command: Command to execute
+            timeout: Command timeout in seconds
+
+        Returns:
+            Tuple of (exit_code, stdout, stderr)
+        """
+        # Parse SSH key
+        key_file = io.StringIO(self.ssh_key_content)
+        ssh_key = paramiko.RSAKey.from_private_key(key_file)
+
+        # Create SSH client
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        try:
+            print(f"Connecting to {host}...")
+            ssh.connect(
+                hostname=host,
+                username='root',
+                pkey=ssh_key,
+                timeout=30,
+            )
+
+            print(f"Executing: {command}")
+            stdin, stdout, stderr = ssh.exec_command(
+                command,
+                timeout=timeout,
+                get_pty=True
+            )
+
+            # Wait for command to complete
+            exit_status = stdout.channel.recv_exit_status()
+
+            stdout_text = stdout.read().decode('utf-8')
+            stderr_text = stderr.read().decode('utf-8')
+
+            return exit_status, stdout_text, stderr_text
+
+        finally:
+            ssh.close()
+
+    def install_armbian_config(self, host: str) -> bool:
+        """
+        Install armbian-config on the server.
+
+        Args:
+            host: Server IP address
+
+        Returns:
+            True if successful, False otherwise
+        """
+        print(f"Installing armbian-config on {host}...")
+
+        # Commands to install armbian-config
+        commands = [
+            # Update package list
+            "apt-get update",
+            # Install required dependencies
+            "apt-get install -y curl git",
+            # Install armbian-config
+            "curl -s https://raw.githubusercontent.com/armbian/config/master/requirements.sh | bash",
+        ]
+
+        for cmd in commands:
+            exit_code, stdout, stderr = self.execute_ssh_command(host, cmd, timeout=180)
+            if exit_code != 0:
+                print(f"Command failed: {cmd}")
+                print(f"stderr: {stderr}")
+                return False
+            print(f"Command succeeded: {cmd}")
+
+        print("armbian-config installed successfully!")
+        return True
+
+    def install_runner(self, host: str) -> bool:
+        """
+        Install GitHub Actions runner using armbian-config.
+
+        Args:
+            host: Server IP address
+
+        Returns:
+            True if successful, False otherwise
+        """
+        print(f"Installing GitHub Actions runner on {host}...")
+
+        # Build the armbian-config command
+        cmd = (
+            f"armbian-config --api "
+            f"module_armbian_runners "
+            f"install "
+            f"gh_token={self.github_token} "
+            f"runner_name={self.runner_name} "
+            f"start={self.start} "
+            f"stop={self.stop} "
+            f"label_primary={self.label_primary} "
+            f"label_secondary={self.label_secondary} "
+            f"organisation={self.organisation}"
+        )
+
+        exit_code, stdout, stderr = self.execute_ssh_command(host, cmd, timeout=600)
+
+        if exit_code != 0:
+            print(f"Runner installation failed!")
+            print(f"stdout: {stdout}")
+            print(f"stderr: {stderr}")
+            return False
+
+        print("Runner installed successfully!")
+        print(f"Output: {stdout}")
+        return True
+
+    def deploy_server(
+        self,
+        machine_index: int,
+        delete_existing: bool = False,
+        install_runner: bool = True,
+    ) -> Optional[Dict]:
+        """
+        Deploy a single server with GitHub Actions runner.
+
+        Args:
+            machine_index: Index into MACHINE_NAMES array
+            delete_existing: Delete existing server if present
+            install_runner: Whether to install the runner
+
+        Returns:
+            Dictionary with server info or None on failure
+        """
+        if machine_index < 0 or machine_index >= len(MACHINE_NAMES):
+            print(f"Error: machine_index {machine_index} out of range (0-{len(MACHINE_NAMES)-1})")
+            return None
+
+        server_name = MACHINE_NAMES[machine_index]
+        print(f"\n=== Deploying server: {server_name} ===")
+
+        # Check if server exists
+        if self.server_exists(server_name):
+            if delete_existing:
+                print(f"Server {server_name} already exists, deleting...")
+                self.delete_server(server_name)
+                time.sleep(5)  # Wait for deletion to complete
+            else:
+                print(f"Server {server_name} already exists. Use --delete-existing to replace it.")
+                return None
+
+        # Get SSH key
+        ssh_key = self.get_ssh_key()
+        if not ssh_key:
+            print(f"Error: SSH key '{self.ssh_key_name}' not found in Hetzner!")
+            return None
+
+        print(f"Creating server {server_name}...")
+        print(f"  Type: {self.machine_type}")
+        print(f"  Image: {self.image_name}")
+        print(f"  SSH Key: {ssh_key.name}")
+
+        # Create server
+        try:
+            response = self.client.servers.create(
+                name=server_name,
+                server_type=ServerType(name=self.machine_type),
+                image=Image(name=self.image_name),
+                ssh_keys=[ssh_key],
+            )
+
+            # Wait for server to be created
+            print(f"Waiting for server creation to complete...")
+            response.action.wait(timeout=300)  # type: ignore
+            print(f"Server {server_name} created!")
+
+        except Exception as e:
+            print(f"Error creating server: {e}")
+            return None
+
+        # Wait for server to be running
+        if not self.wait_for_server_running(server_name):
+            print("Server did not become running in time")
+            return None
+
+        # Get server IP
+        server_ip = self.get_server_public_ip(server_name)
+        if not server_ip:
+            print("Could not get server IP")
+            return None
+
+        print(f"Server IP: {server_ip}")
+
+        result = {
+            "name": server_name,
+            "index": machine_index,
+            "ip": server_ip,
+            "runner_installed": False,
+        }
+
+        # Install armbian-config and runner
+        if install_runner:
+            if self.install_armbian_config(server_ip):
+                if self.install_runner(server_ip):
+                    result["runner_installed"] = True
+                else:
+                    print("Runner installation failed!")
+            else:
+                print("armbian-config installation failed!")
+
+        return result
+
+    def delete_all_servers(self) -> int:
+        """
+        Delete all runner servers.
+
+        Returns:
+            Number of servers deleted
+        """
+        print("=== Deleting all runner servers ===")
+        deleted = 0
+        servers = self.client.servers.get_all()
+
+        for server in servers:
+            if server.name in MACHINE_NAMES:
+                print(f"Deleting server: {server.name} (ID: {server.id})")
+                self.client.servers.delete(server)
+                deleted += 1
+
+        print(f"Deleted {deleted} server(s)")
+        return deleted
+
+
+def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Deploy Hetzner servers with GitHub Actions runners"
+    )
+    parser.add_argument(
+        "action",
+        choices=["enable", "disable", "deploy"],
+        help="Action to perform"
+    )
+    parser.add_argument(
+        "--hetzner-token",
+        required=True,
+        help="Hetzner Cloud API token (HCLOUD_TOKEN env var also works)"
+    )
+    parser.add_argument(
+        "--github-token",
+        required=True,
+        help="GitHub personal access token (GITHUB_TOKEN env var also works)"
+    )
+    parser.add_argument(
+        "--ssh-key",
+        help="Path to SSH private key (SSH_KEY env var also works)"
+    )
+    parser.add_argument(
+        "--ssh-key-name",
+        default="TORRENT",
+        help="Name of SSH key in Hetzner Cloud (default: TORRENT)"
+    )
+    parser.add_argument(
+        "--machine-type",
+        default="cax31",
+        help="Hetzner server type (default: cax31)"
+    )
+    parser.add_argument(
+        "--image",
+        default="ubuntu-22.04",
+        help="OS image name (default: ubuntu-22.04)"
+    )
+    parser.add_argument(
+        "--machine-id",
+        type=int,
+        default=0,
+        help="Machine ID/index (0-7, default: 0)"
+    )
+    parser.add_argument(
+        "--machine-count",
+        type=int,
+        default=1,
+        help="Number of machines to create (default: 1)"
+    )
+    parser.add_argument(
+        "--delete-existing",
+        action="store_true",
+        help="Delete existing server before creating new one"
+    )
+    parser.add_argument(
+        "--runner-name",
+        default="runner",
+        help="Base name for the runner (default: runner)"
+    )
+    parser.add_argument(
+        "--start",
+        type=int,
+        default=1,
+        help="Start hour for runner availability (default: 1)"
+    )
+    parser.add_argument(
+        "--stop",
+        type=int,
+        default=24,
+        help="Stop hour for runner availability (default: 24)"
+    )
+    parser.add_argument(
+        "--label-primary",
+        default="self-hosted",
+        help="Primary runner labels (default: self-hosted)"
+    )
+    parser.add_argument(
+        "--label-secondary",
+        default="",
+        help="Secondary runner labels (default: empty)"
+    )
+    parser.add_argument(
+        "--organisation",
+        default="",
+        help="GitHub organization name"
+    )
+    parser.add_argument(
+        "--output-json",
+        action="store_true",
+        help="Output results as JSON"
+    )
+
+    args = parser.parse_args()
+
+    # Get tokens from args or environment
+    hetzner_token = args.hetzner_token or os.environ.get("HCLOUD_TOKEN")
+    github_token = args.github_token or os.environ.get("GITHUB_TOKEN")
+
+    if not hetzner_token:
+        print("Error: Hetzner token required (use --hetzner-token or HCLOUD_TOKEN env var)")
+        sys.exit(1)
+
+    if not github_token:
+        print("Error: GitHub token required (use --github-token or GITHUB_TOKEN env var)")
+        sys.exit(1)
+
+    # Create deployer
+    deployer = RunnerDeployer(
+        hetzner_token=hetzner_token,
+        github_token=github_token,
+        ssh_key_path=args.ssh_key,
+        ssh_key_name=args.ssh_key_name,
+        machine_type=args.machine_type,
+        image_name=args.image,
+        runner_name=args.runner_name,
+        start=args.start,
+        stop=args.stop,
+        label_primary=args.label_primary,
+        label_secondary=args.label_secondary,
+        organisation=args.organisation,
+    )
+
+    # Execute action
+    if args.action == "disable":
+        deleted = deployer.delete_all_servers()
+        result = {"action": "disable", "deleted": deleted}
+    else:  # enable or deploy
+        results = []
+        for i in range(args.machine_count):
+            machine_id = args.machine_id + i
+            if machine_id >= len(MACHINE_NAMES):
+                print(f"Warning: machine_id {machine_id} exceeds available names (max: {len(MACHINE_NAMES)-1})")
+                break
+
+            result = deployer.deploy_server(
+                machine_index=machine_id,
+                delete_existing=args.delete_existing,
+                install_runner=True,
+            )
+            if result:
+                results.append(result)
+
+        result = {
+            "action": args.action,
+            "servers": results,
+        }
+
+    # Output
+    if args.output_json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"\n=== Result ===")
+        print(json.dumps(result, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add create_servers.py with cloud-init for Docker, armbian-config, and runners
- Add 10GB swap file configuration
- Add runner-count parameter for multiple runners per machine
- Fix delete action to not require github-token
- Change server prefix to hetzner-runner

## Changes

### New files
- hetzner/create_servers.py - Python script for Hetzner server creation using hcloud library

### Modified files
- hetzner/action.yml - Added runner-count input parameter
- hetzner/deploy_runners.py - Updated deployment script

### Key features
- Cloud-init configuration for automatic server setup
- Docker installation via get.docker.com
- Armbian config repository integration
- GitHub Actions runner installation via armbian-config
- Configurable number of runners per machine (start/stop parameters)
- 10GB swap file for improved memory management