### PR TITLE
Add automatic fallback to smaller Hetzner server types with runner count scaling

### DIFF
--- a/hetzner/create_servers.py
+++ b/hetzner/create_servers.py
@@ -21,6 +21,7 @@ try:
     from hcloud.server_types import ServerType
     from hcloud.ssh_keys import SSHKey
     from hcloud.servers.domain import Server
+    from hcloud._exceptions import APIException
     print("[DEBUG] All imports successful")
 except ImportError as e:
     print(f"Missing required library: {e}")
@@ -30,6 +31,13 @@ except ImportError as e:
 
 # Server name prefix
 SERVER_PREFIX = "hetzner-runner"
+
+# Server type fallback order (largest to smallest)
+SERVER_TYPE_FALLBACKS = {
+    "cax41": ["cax41", "cax31", "cax21"],
+    "cax31": ["cax31", "cax21"],
+    "cax21": ["cax21"],
+}
 
 
 def get_cloud_init_config(github_token: str, runner_name: str, runner_count: int = 2) -> str:
@@ -152,20 +160,48 @@ def create_server(
     user_data = get_cloud_init_config(github_token, name, runner_count)
     print(f"[DEBUG] Cloud-init config length: {len(user_data)} bytes")
 
-    # Create server
-    print(f"Creating server: {name}")
-    try:
-        response = client.servers.create(
-            name=name,
-            server_type=ServerType(name=server_type),
-            image=Image(name=image),
-            ssh_keys=[ssh_key] if ssh_key else [],
-            user_data=user_data,
-        )
-        print(f"[DEBUG] Server creation initiated")
-    except Exception as e:
-        print(f"[ERROR] Server creation failed: {e}")
-        raise
+    # Get fallback server types
+    fallback_types = SERVER_TYPE_FALLBACKS.get(server_type, [server_type])
+    print(f"[DEBUG] Will try server types in order: {fallback_types}")
+
+    # Try creating server with fallback to smaller types
+    response = None
+    actual_server_type = None
+
+    for i, try_type in enumerate(fallback_types):
+        print(f"Attempting to create server {name} with type {try_type} (attempt {i+1}/{len(fallback_types)})...")
+
+        try:
+            response = client.servers.create(
+                name=name,
+                server_type=ServerType(name=try_type),
+                image=Image(name=image),
+                ssh_keys=[ssh_key] if ssh_key else [],
+                user_data=user_data,
+            )
+            actual_server_type = try_type
+            print(f"[DEBUG] Server creation initiated with type {try_type}")
+            break
+        except APIException as e:
+            if "resource_unavailable" in str(e) or "placement" in str(e):
+                print(f"[WARNING] Server type {try_type} unavailable: {e}")
+                if i < len(fallback_types) - 1:
+                    print(f"[INFO] Retrying with smaller server type...")
+                    continue
+                else:
+                    print(f"[ERROR] All server types exhausted. Last error: {e}")
+                    raise
+            else:
+                # Not a placement error, re-raise immediately
+                print(f"[ERROR] Server creation failed with non-placement error: {e}")
+                raise
+        except Exception as e:
+            print(f"[ERROR] Server creation failed: {e}")
+            raise
+
+    if not response or not actual_server_type:
+        print(f"[ERROR] Failed to create server after trying all types")
+        raise Exception("Server creation failed: all types exhausted")
 
     # Wait for server creation to complete
     if response.action:
@@ -197,7 +233,13 @@ def create_server(
         "public_ip": server.public_net.ipv4.ip if server.public_net else None,
         "server_type": server.server_type.name,
         "image": server.image.name if server.image else None,
+        "requested_type": server_type,
     }
+
+    # Warn if we had to fall back to a smaller type
+    if actual_server_type != server_type:
+        print(f"[WARNING] Requested {server_type} but created {actual_server_type} due to capacity constraints")
+
     print(f"[DEBUG] Server creation result: {result}")
     return result
 

--- a/hetzner/create_servers.py
+++ b/hetzner/create_servers.py
@@ -39,6 +39,16 @@ SERVER_TYPE_FALLBACKS = {
     "cax21": ["cax21"],
 }
 
+# Maximum runners per server type (assuming 8GB per runner)
+# cax41: 16 vCPU, 32GB RAM → 4 runners
+# cax31: 8 vCPU, 16GB RAM → 2 runners
+# cax21: 4 vCPU, 8GB RAM → 1 runner
+MAX_RUNNERS_PER_TYPE = {
+    "cax41": 4,
+    "cax31": 2,
+    "cax21": 1,
+}
+
 
 def get_cloud_init_config(github_token: str, runner_name: str, runner_count: int = 2) -> str:
     """Generate cloud-init configuration with GitHub token injected."""
@@ -155,21 +165,32 @@ def create_server(
     else:
         print(f"[DEBUG] Using SSH key: {ssh_key.name}")
 
-    # Get cloud-init config with GitHub token
-    print(f"[DEBUG] Generating cloud-init config...")
-    user_data = get_cloud_init_config(github_token, name, runner_count)
-    print(f"[DEBUG] Cloud-init config length: {len(user_data)} bytes")
-
     # Get fallback server types
     fallback_types = SERVER_TYPE_FALLBACKS.get(server_type, [server_type])
     print(f"[DEBUG] Will try server types in order: {fallback_types}")
 
+    # Store original requested runner count
+    requested_runner_count = runner_count
+
     # Try creating server with fallback to smaller types
     response = None
     actual_server_type = None
+    actual_runner_count = None
 
     for i, try_type in enumerate(fallback_types):
         print(f"Attempting to create server {name} with type {try_type} (attempt {i+1}/{len(fallback_types)})...")
+
+        # Adjust runner count based on server type
+        max_runners = MAX_RUNNERS_PER_TYPE.get(try_type, 1)
+        actual_runner_count = min(requested_runner_count, max_runners)
+
+        if try_type != server_type:
+            print(f"[INFO] Adjusted runner count from {requested_runner_count} to {actual_runner_count} for {try_type}")
+
+        # Generate cloud-init config with adjusted runner count
+        print(f"[DEBUG] Generating cloud-init config with {actual_runner_count} runner(s)...")
+        user_data = get_cloud_init_config(github_token, name, actual_runner_count)
+        print(f"[DEBUG] Cloud-init config length: {len(user_data)} bytes")
 
         try:
             response = client.servers.create(
@@ -183,7 +204,8 @@ def create_server(
             print(f"[DEBUG] Server creation initiated with type {try_type}")
             break
         except APIException as e:
-            if "resource_unavailable" in str(e) or "placement" in str(e):
+            error_str = str(e).lower()
+            if "resource_unavailable" in error_str or "placement" in error_str or "unavailable" in error_str:
                 print(f"[WARNING] Server type {try_type} unavailable: {e}")
                 if i < len(fallback_types) - 1:
                     print(f"[INFO] Retrying with smaller server type...")
@@ -234,11 +256,15 @@ def create_server(
         "server_type": server.server_type.name,
         "image": server.image.name if server.image else None,
         "requested_type": server_type,
+        "requested_runners": requested_runner_count,
+        "actual_runners": actual_runner_count,
     }
 
-    # Warn if we had to fall back to a smaller type
+    # Warn if we had to fall back to a smaller type or fewer runners
     if actual_server_type != server_type:
         print(f"[WARNING] Requested {server_type} but created {actual_server_type} due to capacity constraints")
+    if actual_runner_count != requested_runner_count:
+        print(f"[WARNING] Requested {requested_runner_count} runners but configured {actual_runner_count} for {actual_server_type}")
 
     print(f"[DEBUG] Server creation result: {result}")
     return result


### PR DESCRIPTION
## Summary
- Adds automatic fallback to smaller Hetzner server types when requested type is unavailable due to capacity constraints
- Automatically scales runner count based on server size (8GB per runner)
- Improves reliability when ARM64 server capacity is limited

## Problem
Hetzner ARM64 servers (cax series) frequently experience capacity issues, causing `resource_unavailable` placement errors:
```
hcloud._exceptions.APIException: error during placement (resource_unavailable, ...)
```

This results in failed GitHub Actions runs when trying to provision runners.

## Solution
Implemented intelligent fallback logic that:

1. **Tries multiple server types** in order of size:
   - cax41 (32GB) → cax31 (16GB) → cax21 (8GB)
   - cax31 (16GB) → cax21 (8GB)
   - cax21 (8GB) only

2. **Scales runner count** based on actual server type:
   - cax41: max 4 runners (32GB / 8GB per runner)
   - cax31: max 2 runners (16GB / 8GB per runner)
   - cax21: max 1 runner (8GB / 8GB per runner)

3. **Provides clear feedback** on what was actually created:
   ```json
   {
     "requested_type": "cax41",
     "server_type": "cax31",
     "requested_runners": 4,
     "actual_runners": 2
   }
   ```

## Changes
- Added `SERVER_TYPE_FALLBACKS` mapping for fallback chain
- Added `MAX_RUNNERS_PER_TYPE` mapping for runner limits
- Implemented retry loop with placement error detection
- Moved cloud-init config generation inside retry loop
- Enhanced result output with requested vs actual values
- Added warnings when fallback occurs

## Test plan
- [ ] Test with cax41 availability - should create cax41 with 4 runners
- [ ] Test with cax41 unavailable - should fallback to cax31 with 2 runners
- [ ] Test with both cax41/cax31 unavailable - should fallback to cax21 with 1 runner
- [ ] Verify warnings appear in logs when fallback occurs
- [ ] Confirm runner installation works with scaled counts