### PR TITLE
make-yaml-redirector: add more special extensions

### DIFF
--- a/make-yaml-redirector/action.yml
+++ b/make-yaml-redirector/action.yml
@@ -77,9 +77,14 @@ runs:
             - boot.bin.xz: -boot
             - u-boot.rom.xz: -u-boot-rom
             - hyperv.zip: -hyperv
+            - hyperv.zip.xz: -hyperv
             - hyperv.img.xz: -hyperv
             - fip.img.xz: -fip
             - lk.bin.xz: -lk-bin
+            - boe.img.xz: -boe
+            - csot.img.xz: -csot
+            - kebab.img.xz: -kebab
+            - recovery.img.xz: -recovery
 
           servers:
           EOF


### PR DESCRIPTION
Follow-up to #16.

The `armbian-images.json` generator emits these `file_extension` values that are not yet registered in `specialExtensions`, so `loadMapJSON` never appends the matching suffix to the map key and every `redi_url` for these images 404s via the mirror:

| file_extension | suffix | affected boards |
|---|---|---|
| `boe.img.xz` | `-boe` | xiaomi-elish (boot payload) |
| `csot.img.xz` | `-csot` | xiaomi-elish (boot payload) |
| `kebab.img.xz` | `-kebab` | oneplus-kebab (boot payload) |
| `recovery.img.xz` | `-recovery` | recovery boot payload |
| `hyperv.zip.xz` | `-hyperv` | uefi-arm64, uefi-x86 (Hyper-V cloud) |

The audit in armbian/armbian.github.io#277 flagged 9 broken URLs that these entries fix.

## Related

- armbian/armbian.github.io#277 (generator-side `.tar.xz` fix)
- armbian/armbian-router#40 (router-side `.tar.xz` + matching `dlrouter.yaml`)

/cc @igorpecovnik @efectn