### PR TITLE
runner-clean: export per-runner proxy env and route git via git_cdn

### DIFF
--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -60,11 +60,3 @@ runs:
         run: |
           sudo chown -R $USER:$USER . 2> /dev/null || true
           sudo rm -f lib/tools/common/__pycache__/bash_declare_parser.cpython-310.pyc 2> /dev/null || true
-
-      - name: "Remove Other projects"
-        if: ${{ env.RUNNER_USER != 'runner' }}
-        shell: bash
-        run: |
-          PROJECT=$(echo ${{ github.workspace }} | rev | cut -d'/' -f 1 | rev)
-          sudo find $(echo ${{ github.workspace }} | rev | cut -d"/" -f3- | rev) \
-          -mindepth 1 -maxdepth 1 ! -name "_*" ! -name ${PROJECT} -exec sudo rm -rf {} + || true

--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -1,6 +1,6 @@
-name: "Runner cleaning"
+name: "Runner setup and cleaning"
 author: "Igor Pecovnik"
-description: "Cleaning self hosted runners"
+description: "Configure self hosted runner proxies/caches and clean its workspace"
 runs:
   using: "composite"
   steps:

--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -40,18 +40,20 @@ runs:
         if: ${{ env.RUNNER_USER != 'runner' }}
         shell: bash
         run: |
-          # clean toolchain/rootfs/sources only if usage goes over 70% (arbitrary)
-          if [[ $(df --total -hl --output=pcent | tail -1 | xargs | sed "s/%//g") -gt 70 ]]; then
+          # clean toolchain/rootfs/sources and debs only if usage goes over 90% (arbitrary)
+          if [[ $(df --total -hl --output=pcent | tail -1 | xargs | sed "s/%//g") -gt 90 ]]; then
               sudo rm -rf cache/toolchain/*
               sudo rm -rf cache/rootfs/*
               sudo rm -rf build/cache/toolchain/*
               sudo rm -rf build/cache/rootfs/*
               sudo rm -rf cache/sources/*
               sudo rm -rf build/cache/sources/*
+              sudo rm -rf output/{debs,debs-beta}/*
+              sudo rm -rf build/output/{debs,debs-beta}/*
           fi
-          sudo rm -rf output/{images,debs,debs-beta}/*
+          sudo rm -rf output/images/*
           sudo rm -rf userpatches/*
-          sudo rm -rf build/output/{images,debs,debs-beta}/*
+          sudo rm -rf build/output/images/*
           sudo rm -rf build/userpatches/*
 
       - name: "Fix permissions"

--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -23,7 +23,13 @@ runs:
             echo "${var}=${value}" >> "$GITHUB_ENV"
           done
 
-          # git proxy: route github.com through the local git_cdn mirror
+          # git proxy: route github.com through the local git_cdn mirror.
+          # Clear any previous rewrite first (the proxy may have changed or been
+          # dropped in NetBox); ~/.gitconfig persists on the machine otherwise.
+          while read -r key _; do
+            git config --global --unset-all "$key" '^https://github\.com/$' 2>/dev/null || true
+          done < <(git config --global --get-regexp '\.insteadof$' 2>/dev/null | grep -i 'https://github.com/$' | awk '{print $1}')
+
           git_proxy="$(jq -r '.git_proxy // ""' <<< "$info")"
           if [[ -n "$git_proxy" ]]; then
             echo "git config --global url.\"${git_proxy}\".insteadOf https://github.com/"

--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -40,12 +40,12 @@ runs:
         if: ${{ env.RUNNER_USER != 'runner' }}
         shell: bash
         run: |
-          sudo rm -rf cache/toolchain/*
-          sudo rm -rf cache/rootfs/*
-          sudo rm -rf build/cache/toolchain/*
-          sudo rm -rf build/cache/rootfs/*
-          # clean sources only if usage goes over 70% (arbitrary)
+          # clean toolchain/rootfs/sources only if usage goes over 70% (arbitrary)
           if [[ $(df --total -hl --output=pcent | tail -1 | xargs | sed "s/%//g") -gt 70 ]]; then
+              sudo rm -rf cache/toolchain/*
+              sudo rm -rf cache/rootfs/*
+              sudo rm -rf build/cache/toolchain/*
+              sudo rm -rf build/cache/rootfs/*
               sudo rm -rf cache/sources/*
               sudo rm -rf build/cache/sources/*
           fi

--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -1,22 +1,45 @@
-name: "Runner clening"
+name: "Runner cleaning"
 author: "Igor Pecovnik"
 description: "Cleaning self hosted runners"
 runs:
   using: "composite"
   steps:
 
-      - name: "Remove JSON files"
-        if: ${{ env.RUNNER_USER != runner }}
+      - name: "Runner info for ${{ runner.name }}"
         shell: bash
         run: |
+          info="$(curl -fsSL "https://github.armbian.com/servers/github-runners.jq" \
+            | jq --arg name "${{ runner.name }}" '
+                ($name | sub("-[0-9]+$"; "")) as $base
+                | first(.[] | select((.host | split(".")[0]) == $base)) // {}
+              ')"
+          echo "Runner info for ${{ runner.name }}:"
+          echo "$info"
+          echo "--- Exported environment ---"
+          for map in apt_proxy:APT_PROXY_ADDR oci_cache:GHCR_MIRROR_ADDRESS redis_cache:CCACHE_REMOTE_STORAGE; do
+            key="${map%%:*}"; var="${map##*:}"
+            value="$(jq -r --arg k "$key" '.[$k] // ""' <<< "$info")"
+            echo "${var}=${value}"
+            echo "${var}=${value}" >> "$GITHUB_ENV"
+          done
 
+          # git proxy: route github.com through the local git_cdn mirror
+          git_proxy="$(jq -r '.git_proxy // ""' <<< "$info")"
+          if [[ -n "$git_proxy" ]]; then
+            echo "git config --global url.\"${git_proxy}\".insteadOf https://github.com/"
+            git config --global url."${git_proxy}".insteadOf https://github.com/
+          fi
+
+      - name: "Remove JSON files"
+        if: ${{ env.RUNNER_USER != 'runner' }}
+        shell: bash
+        run: |
           sudo rm -rf JSON *.json *.tmp *.parts
 
       - name: "Remove output folder"
-        if: ${{ env.RUNNER_USER != runner }}
+        if: ${{ env.RUNNER_USER != 'runner' }}
         shell: bash
         run: |
-
           sudo rm -rf cache/toolchain/*
           sudo rm -rf cache/rootfs/*
           sudo rm -rf build/cache/toolchain/*
@@ -25,36 +48,23 @@ runs:
           if [[ $(df --total -hl --output=pcent | tail -1 | xargs | sed "s/%//g") -gt 70 ]]; then
               sudo rm -rf cache/sources/*
               sudo rm -rf build/cache/sources/*
-          fi          
+          fi
           sudo rm -rf output/{images,debs,debs-beta}/*
           sudo rm -rf userpatches/*
           sudo rm -rf build/output/{images,debs,debs-beta}/*
           sudo rm -rf build/userpatches/*
-          
 
       - name: "Fix permissions"
-        if: ${{ env.RUNNER_USER != runner }}
-        shell: bash 
+        if: ${{ env.RUNNER_USER != 'runner' }}
+        shell: bash
         run: |
-        
-          #sudo chown -R $USER:$USER cache/. 2> /dev/null || true
           sudo chown -R $USER:$USER . 2> /dev/null || true
-          #sudo rm -f build/lib/tools/common/__pycache__/bash_declare_parser.cpython-310.pyc 2> /dev/null || true
           sudo rm -f lib/tools/common/__pycache__/bash_declare_parser.cpython-310.pyc 2> /dev/null || true
 
-      - name: Remove dangling Docker images
-        if: ${{ env.RUNNER_USER != runner }}
-        shell: bash 
+      - name: "Remove Other projects"
+        if: ${{ env.RUNNER_USER != 'runner' }}
+        shell: bash
         run: |
-
-          # sudo docker image prune -a --force || true
-
-      - name: Remove Other projects
-        if: ${{ env.RUNNER_USER != runner }}
-        shell: bash 
-        run: |
-
-          cd ../..
           PROJECT=$(echo ${{ github.workspace }} | rev | cut -d'/' -f 1 | rev)
           sudo find $(echo ${{ github.workspace }} | rev | cut -d"/" -f3- | rev) \
           -mindepth 1 -maxdepth 1 ! -name "_*" ! -name ${PROJECT} -exec sudo rm -rf {} + || true


### PR DESCRIPTION
## What

Reworks the `runner-clean` composite action so each self-hosted runner is configured from its NetBox-derived record, and tidies the cleanup logic.

### Runner info / proxy setup (new step)

Looks the current runner up in [`github-runners.jq`](https://github.armbian.com/servers/github-runners.jq) by its base name (`ampere-1-76` → `ampere-1`) and wires up its caches/proxies:

- Exports env for the build framework:
  - `apt_proxy` → `APT_PROXY_ADDR`
  - `oci_cache` → `GHCR_MIRROR_ADDRESS`
  - `redis_cache` → `CCACHE_REMOTE_STORAGE`
- When `git_proxy` is set, inserts a global git rewrite:
  ```
  git config --global url."<git_proxy>".insteadOf https://github.com/
  ```
  Because `runner-clean` runs **before** the checkout step, the subsequent `actions/checkout` then clones through the local **git_cdn** mirror (e.g. `http://10.0.40.70:8000/`), cutting WAN usage on big repos.

The fields come from the NetBox runner export (`generate-servers-jsons.yml`), which already emits `git_proxy`. Missing fields default to empty, so it's a no-op on runners without proxies configured.

### Cleanup changes

- Fixed the always-true guard `if: ${{ env.RUNNER_USER != runner }}` → `!= 'runner'` (unquoted `runner` was the context object, so the guard never skipped).
- **Disk-usage gating:** `toolchain`, `rootfs`, `sources`, and `output/{debs,debs-beta}` are now purged only when disk usage exceeds **90%** (raised from 70%); `output/images` and `userpatches` are still cleared every run. Keeps warm caches around for faster builds until the disk is genuinely full.
- Removed the **Remove Other projects** step (aggressive sibling-dir `rm -rf`).
- Removed the dead **Remove dangling Docker images** step (only a comment) and the no-op `cd ../..`.
- Fixed the `name:` typo (`clening` → `cleaning`) and trimmed whitespace.

## Validation

- YAML parses; all composite `run` steps have `shell:`.
- Simulated the jq lookup + export with real `github-runners.jq` data for `ampere-1-76` → correct env, and `git config --global url."http://10.0.40.70:8000/".insteadOf https://github.com/` applied.