### PR TITLE
runner-clean: export per-runner xz memory cap (IMAGE_XZ_MEMLIMIT)

### DIFF
--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -40,6 +40,17 @@ runs:
             git config --global url."${git_proxy}".insteadOf https://github.com/
           fi
 
+          # Per-runner xz memory cap: 70% of host RAM split across its runners,
+          # leaving headroom for the OS and the build itself. Consumed by the
+          # build's `xz --memlimit-compress` (overrides its 10 GiB default).
+          mem_mb="$(jq -r '.memory // 0' <<< "$info")"
+          n_runners="$(jq -r '.runners // 0' <<< "$info")"
+          if (( mem_mb > 0 && n_runners > 0 )); then
+            xz_cap_mb=$(( mem_mb * 7 / 10 / n_runners ))
+            echo "IMAGE_XZ_MEMLIMIT=${xz_cap_mb}MiB"
+            echo "IMAGE_XZ_MEMLIMIT=${xz_cap_mb}MiB" >> "$GITHUB_ENV"
+          fi
+
       - name: "Remove JSON files"
         if: ${{ env.RUNNER_USER != 'runner' }}
         shell: bash


### PR DESCRIPTION
## What

Adds a per-runner xz memory cap to the `Runner info` step. From the runner's `github-runners.jq` record (which carries `memory` MB and `runners` count) it computes:

```
IMAGE_XZ_MEMLIMIT = memory * 0.7 / runners   (MiB)
```

and exports it to `$GITHUB_ENV`. The build's `xz --memlimit-compress` then uses this instead of its 10 GiB default, so a host running many runners caps each xz process to a fair share of RAM and parallel image compressions can't collectively OOM.

- 70% leaves headroom for the OS and the build itself.
- Example — **kspace** (memory 270129 MB, 24 runners): `IMAGE_XZ_MEMLIMIT=7878MiB` (~7.7 GiB).
- If `memory`/`runners` are missing, nothing is exported and the build keeps its built-in 10 GiB default (which itself lowers to MemAvailable on small hosts).

Pairs with armbian/build's `xz --memlimit-compress` support and the 16-thread cap.

## Validation

- YAML parses.
- Calc verified for kspace (`270129*0.7/24 = 7878MiB`) and the missing-field edge case (no export → build default).