### PR TITLE
runner-clean: selectively chown root-owned workspace files before checkout

### DIFF
--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -81,6 +81,15 @@ runs:
         if: ${{ env.RUNNER_USER != 'runner' }}
         shell: bash
         run: |
-          # Temporarily disabled to check whether this is still needed:
-          #sudo chown -R $USER:$USER . 2> /dev/null || true
+          # Docker/chroot build steps leave some files under the workspace owned
+          # by root (e.g. cache/aptcache/lists). actions/checkout's pre-checkout
+          # "Deleting the contents of ..." runs as the runner user (no sudo) and
+          # then fails with: EACCES: permission denied, rmdir '.../cache/aptcache/lists'.
+          # Chown those back to the runner user — but *selectively*: only files
+          # NOT already owned by this user/group, so we skip the vast majority of
+          # correctly-owned files instead of a full recursive chown of a multi-GB
+          # workspace on every run (which is why the blanket chown was dropped).
+          me_u="$(id -un)"; me_g="$(id -gn)"
+          sudo find . \( ! -user "$me_u" -o ! -group "$me_g" \) -exec chown "${me_u}:${me_g}" {} + 2> /dev/null || true
+
           sudo rm -f lib/tools/common/__pycache__/bash_declare_parser.cpython-310.pyc 2> /dev/null || true


### PR DESCRIPTION
## Problem

Jobs fail at `actions/checkout` before they even start:

```
Deleting the contents of '/home/actions-runner-37/_work/os/os'
Error: File was unable to be removed
Error: EACCES: permission denied, rmdir '.../cache/aptcache/lists'
```

Docker/chroot build steps write some files under the workspace as **root** (apt cache, etc.). When checkout decides to wipe the workspace (its `prepareExistingDirectory` path — unaffected by `clean: false`), it runs as the runner user with Node's `rmRF` (no sudo) and dies on the root-owned dirs.

## Fix

Re-enable the ownership fix that was previously commented out (`#sudo chown -R $USER:$USER .`), but **selectively** — chown only files **not already owned** by the runner user/group:

```bash
me_u="$(id -un)"; me_g="$(id -gn)"
sudo find . \( ! -user "$me_u" -o ! -group "$me_g" \) -exec chown "${me_u}:${me_g}" {} + 2>/dev/null || true
```

This touches only the handful of root-owned paths instead of a full recursive chown of a multi-GB workspace every run — which is why the blanket `chown -R` was dropped. `runner-clean` runs before checkout, so ownership is corrected in time for checkout's cleanup to succeed.

## Notes / follow-ups discussed
- `USE_LOCAL_APT_DEB_CACHE=no` in the build would shed the redundant local apt cache (the runners already have the apt-cacher-ng proxy), removing the most common offender — but other Docker-built caches (`cache/sources`, `cache/rootfs`) are also root-owned, so this chown is the general fix.
- Longer term: moving `${SRC}/cache` out of the checkout workspace (per-runner, outside `_work/.../`) would stop checkout from ever touching it. The build framework has no setting to relocate the cache, so that's a separate runner-side change.