### PR TITLE
runner-clean: normalize http(s)_proxy to runner's advertised apt proxy

### DIFF
--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -23,6 +23,21 @@ runs:
             echo "${var}=${value}" >> "$GITHUB_ENV"
           done
 
+          # Normalize the generic proxy env to THIS runner's advertised apt proxy.
+          # A stale http_proxy in the runner's own environment (e.g. a datacenter
+          # leftover that a host grep won't find) otherwise leaks into builds:
+          # docker.sh forwards http_proxy into the build container, and apt there
+          # points at an unreachable cache (e.g. 10.0.40.2:3142) and times out.
+          # Make the NetBox json the single source of truth — set http(s)_proxy to
+          # the advertised proxy, or blank it when this runner has none. Written via
+          # $GITHUB_ENV so it overrides the runner-injected value for all later steps.
+          apt_proxy="$(jq -r '.apt_proxy // ""' <<< "$info")"
+          proxy_url=""; [[ -n "$apt_proxy" ]] && proxy_url="http://${apt_proxy}"
+          for v in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+            echo "${v}=${proxy_url}"
+            echo "${v}=${proxy_url}" >> "$GITHUB_ENV"
+          done
+
           # git proxy: route github.com through the local git_cdn mirror.
           # Clear any previous rewrite first (the proxy may have changed or been
           # dropped in NetBox); ~/.gitconfig persists on the machine otherwise.


### PR DESCRIPTION
## Problem

Image builds were failing on self-hosted runners that have **no** proxy in NetBox (e.g. `kspace`, `insanisfiction`):

```
W: Failed to fetch http://ports.ubuntu.com/.../InRelease  Unable to connect to 10.0.40.2:3142
```

The runner's json entry is empty and the workflow only sets `APT_PROXY_ADDR` (also empty) — yet apt used `10.0.40.2:3142`. Source: a **stale `http_proxy` baked into the runner's own environment** (a datacenter leftover; invisible to a host-filesystem grep, survives reboots, identical across hosts because runners are provisioned the same). `build`'s `docker.sh` forwards `http_proxy` into the build container, so apt there points at an unreachable cache and times out.

## Fix

`runner-clean` already resolves this runner's config from the NetBox json. Make that json the **single source of truth** for the generic proxy env too: set `http_proxy`/`https_proxy` (lower+upper) to the advertised `apt_proxy`, or **blank them** when the runner has none. Written via `$GITHUB_ENV`, so it overrides whatever the runner injected, for every later step and for `docker.sh`.

Net effect: a stale runner proxy can no longer leak into builds. Datacenter runners (with a real `apt_proxy`) are unchanged; proxy-less runners get a clean environment.

## Scope

Pre-existing issue (the old generated workflows hit it too). Fixing it here covers every consumer of `runner-clean@main` at once, without touching each runner's provisioning.