### PR TITLE
HOTFIX runner-clean: only clear proxy env, never set it to acng (fixes datacenter runners)

### DIFF
--- a/runner-clean/action.yml
+++ b/runner-clean/action.yml
@@ -23,20 +23,22 @@ runs:
             echo "${var}=${value}" >> "$GITHUB_ENV"
           done
 
-          # Normalize the generic proxy env to THIS runner's advertised apt proxy.
-          # A stale http_proxy in the runner's own environment (e.g. a datacenter
-          # leftover that a host grep won't find) otherwise leaks into builds:
-          # docker.sh forwards http_proxy into the build container, and apt there
-          # points at an unreachable cache (e.g. 10.0.40.2:3142) and times out.
-          # Make the NetBox json the single source of truth — set http(s)_proxy to
-          # the advertised proxy, or blank it when this runner has none. Written via
-          # $GITHUB_ENV so it overrides the runner-injected value for all later steps.
+          # Clear a stale generic proxy on runners that advertise NO apt proxy.
+          # Such a leftover (e.g. a datacenter http_proxy a host grep won't find)
+          # leaks into builds — docker.sh forwards http_proxy into the build
+          # container, and apt there points at an unreachable cache (e.g.
+          # 10.0.40.2:3142) and times out. Clear it via $GITHUB_ENV so it can't.
+          # Runners that DO advertise a proxy are left untouched: apt uses
+          # APT_PROXY_ADDR and git uses git_proxy. The apt-cacher-ng address is
+          # apt-only and must NOT become the generic http(s)_proxy (acng can't
+          # proxy general HTTPS like ghcr.io/github.com).
           apt_proxy="$(jq -r '.apt_proxy // ""' <<< "$info")"
-          proxy_url=""; [[ -n "$apt_proxy" ]] && proxy_url="http://${apt_proxy}"
-          for v in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
-            echo "${v}=${proxy_url}"
-            echo "${v}=${proxy_url}" >> "$GITHUB_ENV"
-          done
+          if [[ -z "$apt_proxy" ]]; then
+            for v in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY; do
+              echo "${v}="
+              echo "${v}=" >> "$GITHUB_ENV"
+            done
+          fi
 
           # git proxy: route github.com through the local git_cdn mirror.
           # Clear any previous rewrite first (the proxy may have changed or been


### PR DESCRIPTION
## Urgent — fixes regression from #24

#24 set `http_proxy`/`https_proxy` to the runner's `apt_proxy` when present. But `apt_proxy` is **apt-cacher-ng** (10.0.40.2:3142), which only proxies apt. Forcing it as the *generic* proxy on datacenter runners (geekom, …) routed all HTTPS (ghcr.io, github.com) through acng → everything broke:

```
http_proxy=http://10.0.40.2:3142
https_proxy=http://10.0.40.2:3142   # acng can't proxy general HTTPS -> build dies
```

## Fix

**Clear-only.** Blank `http(s)_proxy` only when the runner advertises **no** `apt_proxy` (the original leak fix for kspace/insanisfiction). Runners that *do* advertise a proxy are left completely untouched — apt uses `APT_PROXY_ADDR`, git uses `git_proxy`. The acng address must never become the generic `http(s)_proxy`.

Restores datacenter runners to their pre-#24 behaviour while still neutralizing the stale-http_proxy leak on proxy-less runners. Please merge ASAP — #24 is currently breaking builds on every proxied runner.